### PR TITLE
fix: white outline on calendar

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -26,6 +26,14 @@ body {
     border-color: var(--background-modifier-border);
   }
 
+  .fc .fc-scrollgrid-section-header.fc-scrollgrid-section-sticky > * {
+    background-color: var(--background-primary);
+  }
+
+  .fc .fc-scrollgrid {
+    border-width: 0px;
+  }
+
   .fc-header-toolbar {
     margin-bottom: 0px !important;
     padding: 8px !important;


### PR DESCRIPTION
Fixes the white outline on the calendar by:
- Removing a white border around the entire calendar
- Making the table header use the user's background color

Closes #8

Before:
<img width="1510" height="384" alt="image" src="https://github.com/user-attachments/assets/65e1ec83-4327-402f-852f-f3043fb7f8ef" />

After:
<img width="1544" height="424" alt="image" src="https://github.com/user-attachments/assets/966096f7-e2b3-40d1-bd97-a8dd40d15620" />
